### PR TITLE
Add verbose logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     ],
     "build": [
       "@cs",
-      "@tests"
+      "@test"
     ],
     "ci": [
       "@composer validate --no-check-publish --no-check-all",

--- a/src/Keboola/GoodDataExtractor/Component.php
+++ b/src/Keboola/GoodDataExtractor/Component.php
@@ -37,6 +37,7 @@ class Component extends BaseComponent
             $credentials = $provisioning->getCredentials($config->getPid());
             $username = $credentials['login'];
             $password = $credentials['password'];
+            $this->getLogger()->info('GoodData credentials obtained from Provisioning.');
         } elseif ($config->getWriterId()) {
             // Extractor will get credentials from Writer configuration (deprecated option)
             $writer = new \Keboola\GoodDataExtractor\Writer(
@@ -46,17 +47,21 @@ class Component extends BaseComponent
             $creds = $writer->getUserCredentials($config->getWriterId());
             $username = $creds['username'];
             $password = $creds['password'];
+            $this->getLogger()->info('GoodData credentials obtained directly from Writer.');
         } else {
             $username = $config->getCredentials()[0];
             $password = $config->getCredentials()[1];
+            $this->getLogger()->info('GoodData credentials obtained from configuration.');
         }
         $url = 'https://' . $config->getHost();
+        $this->getLogger()->info("GoodData backend: {$url}, username: {$username}");
         $app = new \Keboola\GoodDataExtractor\Extractor(
             new \Keboola\GoodData\Client($url),
             $username,
             $password,
             $this->getDataDir() . '/out/tables'
         );
+        $app->setLogger($this->getLogger());
         $app->extract($config->getReports());
     }
 

--- a/src/Keboola/GoodDataExtractor/Extractor.php
+++ b/src/Keboola/GoodDataExtractor/Extractor.php
@@ -6,6 +6,7 @@ namespace Keboola\GoodDataExtractor;
 
 use Keboola\GoodData\Client;
 use Keboola\GoodData\Exception as GoodDataException;
+use Psr\Log\LoggerInterface;
 
 class Extractor
 {
@@ -13,12 +14,26 @@ class Extractor
     protected $gdClient;
     /** @var string  */
     protected $folder;
+    /** @var LoggerInterface */
+    protected $logger;
 
     public function __construct(Client $gdClient, string $username, string $password, string $folder)
     {
         $this->gdClient = $gdClient;
         $this->gdClient->login($username, $password);
         $this->folder = $folder;
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+    }
+
+    protected function log(string $message): void
+    {
+        if (!empty($this->logger)) {
+            $this->logger->info($message);
+        }
     }
 
     public function extract(array $reports): void
@@ -38,15 +53,18 @@ class Extractor
     public function download(string $pid, string $uri, string $filename): void
     {
         try {
+            $this->log("Downloading report '{$uri}'");
             $report = $this->gdClient->get($uri);
             if (!isset($report['report']['content']['definitions'][0])) {
                 throw new Exception("Report '{$uri}' has no definitions to export");
             }
             $reportDefinitions = $report['report']['content']['definitions'];
             $reportDefinitionUri = array_pop($reportDefinitions);
+            $this->log("Found report definition '{$reportDefinitionUri}'");
 
             $responseUri = $this->gdClient->getReports()->export($pid, $reportDefinitionUri);
 
+            $this->log("Downloading report data from '{$responseUri}'");
             $this->gdClient->getToFile($responseUri, $filename);
         } catch (GoodDataException $e) {
             throw new Exception($e->getMessage(), 400, $e);

--- a/tests/functional/DatadirTest.php
+++ b/tests/functional/DatadirTest.php
@@ -37,7 +37,8 @@ class DatadirTest extends AbstractDatadirTestCase
         $tempDatadir = $this->getTempDatadir($specification);
         file_put_contents($tempDatadir->getTmpFolder() . '/config.json', \GuzzleHttp\json_encode($config));
         $process = $this->runScript($tempDatadir->getTmpFolder());
-        $this->assertMatchesSpecification($specification, $process, $tempDatadir->getTmpFolder());
+        $this->assertEmpty($process->getErrorOutput());
+        $this->assertEquals(0, $process->getExitCode());
         $this->assertFileExists($tempDatadir->getTmpFolder() . "/out/tables/$reportId.csv");
         $csv = file($tempDatadir->getTmpFolder() . "/out/tables/$reportId.csv");
         $this->assertNotFalse($csv);


### PR DESCRIPTION
Ten fix v composer.json je jen pro docker-compose, v travisu se ten `build` skript nepoužívá.

Datadir testy prošly, dokonce i logují, jak bylo vidět v Travisu než jsem je fixnul: 
![image](https://user-images.githubusercontent.com/215660/74760415-a8d15400-527a-11ea-949a-15198018b2ad.png)
 
